### PR TITLE
修复 tab 补全导致命令行变色的问题

### DIFF
--- a/zxx.zsh-theme
+++ b/zxx.zsh-theme
@@ -55,7 +55,7 @@ PROMPT="
 ${git_info} \
 ${git_last_commit}
 ${time} \
-%{$terminfo[bold]$fg[white]%}› %{$reset_color%}"
+%{$terminfo[bold]$fg[white]%}› %{$reset_color%}%f"
 
 if [[ "$USER" == "root" ]]; then
 PROMPT="


### PR DESCRIPTION
比如文件路径，命令行的 tab 补全，会导致整个命令行从白色变成浅蓝色，跟 time 一个颜色了。

修复后就一致保持白色。